### PR TITLE
fix: trim git config line ending from ignore path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,9 @@ impl Config {
             .args(["config", "--get", key])
             .output()
             .unwrap();
-        String::from_utf8_lossy(&output.stdout).to_string()
+        String::from_utf8_lossy(&output.stdout)
+            .trim_end_matches(['\r', '\n'])
+            .to_string()
     }
 
     pub fn load(&mut self) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,11 +20,13 @@ impl Config {
 
     fn load_git_config(key: &str) -> String {
         let output = Command::new("git")
-            .args(["config", "--get", key])
+            .args(["config", "--null", "--get", key])
             .output()
             .unwrap();
-        String::from_utf8_lossy(&output.stdout)
-            .trim_end_matches(['\r', '\n'])
+        let value = String::from_utf8_lossy(&output.stdout);
+        value
+            .strip_suffix('\0')
+            .unwrap_or(value.as_ref())
             .to_string()
     }
 

--- a/tests/config_path.rs
+++ b/tests/config_path.rs
@@ -3,10 +3,12 @@ use std::{
     process::{self, Command},
 };
 
-#[test]
-fn repo_option_prints_configured_path_once() {
-    let config_path = env::temp_dir().join(format!("git-ignore-config-{}", process::id()));
-    let repo_path = env::temp_dir().join(format!("git ignore repository {}", process::id()));
+fn assert_repo_path(case: &str, suffix: &str) {
+    let config_path = env::temp_dir().join(format!("git-ignore-{case}-config-{}", process::id()));
+    let repo_path = env::temp_dir().join(format!(
+        "git ignore {case} repository {}{suffix}",
+        process::id()
+    ));
     let configured = Command::new("git")
         .args(["config", "--file"])
         .arg(&config_path)
@@ -30,4 +32,15 @@ fn repo_option_prints_configured_path_once() {
         output.stdout,
         format!("{}\n", repo_path.display()).as_bytes()
     );
+}
+
+#[test]
+fn repo_option_prints_configured_path_once() {
+    assert_repo_path("ordinary", "");
+}
+
+#[cfg(unix)]
+#[test]
+fn repo_option_preserves_configured_line_breaks() {
+    assert_repo_path("line-break", "\r\n");
 }

--- a/tests/config_path.rs
+++ b/tests/config_path.rs
@@ -1,0 +1,33 @@
+use std::{
+    env, fs,
+    process::{self, Command},
+};
+
+#[test]
+fn repo_option_prints_configured_path_once() {
+    let config_path = env::temp_dir().join(format!("git-ignore-config-{}", process::id()));
+    let repo_path = env::temp_dir().join(format!("git ignore repository {}", process::id()));
+    let configured = Command::new("git")
+        .args(["config", "--file"])
+        .arg(&config_path)
+        .arg("ignore.path")
+        .arg(&repo_path)
+        .status()
+        .expect("git should be available");
+    assert!(configured.success());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_git-ignore"))
+        .arg("--repo")
+        .env("GIT_CONFIG_GLOBAL", &config_path)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .output()
+        .expect("git-ignore should run");
+
+    fs::remove_file(config_path).expect("temporary config should be removable");
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        output.stdout,
+        format!("{}\n", repo_path.display()).as_bytes()
+    );
+}


### PR DESCRIPTION
## Purpose

Fix configured `ignore.path` values retaining Git's output record delimiter, which made `--repo` print an extra blank line and caused generation to use a nonexistent newline-suffixed path.

## Changes

- Request NUL-delimited output from `git config` and remove exactly one unambiguous terminator.
- Add CLI regression tests for an ordinary configured path containing spaces and a Unix path ending in CRLF.
- Preserve legitimate CR/LF bytes in configured Unix paths per review feedback.

## Verification

- Red 1: the ordinary-path CLI test failed with two trailing LF bytes before the initial fix.
- Red 2: the CRLF-path CLI test failed because `trim_end_matches` removed legitimate path bytes.
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets --all-features`
- `cargo test --all-targets --all-features`
- `cargo llvm-cov --all-features --workspace --summary-only` (21.94% line coverage overall; `config.rs` 100%)
- `cargo audit --deny warnings`

## Related issue

None; discovered during scheduled maintenance.