### PR TITLE
fix: report gitignore clone failures

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod config;
 
 use crate::config::Config;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::{collections::HashMap, env, ffi::OsStr, fs, io, os, path::Path, process::Command};
 use walkdir::{DirEntry, WalkDir};
 
@@ -23,20 +23,25 @@ fn init_gitignore(path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    // create gitignore directory
-    fs::create_dir(path)?;
-
     // clone gitignore repository
-    Command::new("git")
-        .args([
-            "clone",
-            "https://github.com/github/gitignore.git",
-            path.display().to_string().as_str(),
-        ])
+    let output = Command::new("git")
+        .args(["clone", "https://github.com/github/gitignore.git"])
+        .arg(path)
         .output()
-        .unwrap_or_else(|_| panic!("Failed to clone gitignore repository.\nExecuted command: `git clone https://github.com/github/gitignore.git {}`", path.display()));
+        .context("Failed to execute git clone")?;
 
-    Ok(())
+    if output.status.success() {
+        return Ok(());
+    }
+
+    if path.exists() {
+        fs::remove_dir_all(path).context("Failed to clean up incomplete gitignore repository")?;
+    }
+
+    Err(anyhow!(
+        "Failed to clone gitignore repository: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
 }
 
 /// Load gitignore files recursively from `config.gitignore_path`

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,14 @@ mod config;
 
 use crate::config::Config;
 use anyhow::{anyhow, Context, Result};
-use std::{collections::HashMap, env, ffi::OsStr, fs, io, os, path::Path, process::Command};
+use std::{
+    collections::HashMap,
+    env,
+    ffi::OsStr,
+    fs, io, os,
+    path::Path,
+    process::{self, Command},
+};
 use walkdir::{DirEntry, WalkDir};
 
 fn is_git(entry: &DirEntry) -> bool {
@@ -23,7 +30,26 @@ fn init_gitignore(path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    // clone gitignore repository
+    let mut staging_name = path
+        .file_name()
+        .unwrap_or_else(|| OsStr::new("gitignore"))
+        .to_os_string();
+    staging_name.push(format!(".tmp-{}", process::id()));
+    let staging_path = path.with_file_name(staging_name);
+    fs::create_dir(&staging_path).context("Failed to create clone staging directory")?;
+
+    let result = clone_gitignore(&staging_path).and_then(|()| {
+        fs::rename(&staging_path, path).context("Failed to install cloned gitignore repository")
+    });
+    if result.is_err() {
+        fs::remove_dir_all(&staging_path)
+            .context("Failed to clean up incomplete gitignore repository")?;
+    }
+
+    result
+}
+
+fn clone_gitignore(path: &Path) -> Result<()> {
     let output = Command::new("git")
         .args(["clone", "https://github.com/github/gitignore.git"])
         .arg(path)
@@ -32,10 +58,6 @@ fn init_gitignore(path: &Path) -> Result<()> {
 
     if output.status.success() {
         return Ok(());
-    }
-
-    if path.exists() {
-        fs::remove_dir_all(path).context("Failed to clean up incomplete gitignore repository")?;
     }
 
     Err(anyhow!(

--- a/tests/clone_failure.rs
+++ b/tests/clone_failure.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[test]
-fn clone_failure_is_reported_without_leaving_repository_directory() {
+fn clone_failure_is_reported_without_removing_competing_repository() {
     let test_root = env::temp_dir().join(format!("git-ignore-clone-failure-{}", process::id()));
     let bin_dir = test_root.join("bin");
     let repo_path = test_root.join("repository");
@@ -16,7 +16,7 @@ fn clone_failure_is_reported_without_leaving_repository_directory() {
     let git_path = bin_dir.join("git");
     fs::write(
         &git_path,
-        "#!/bin/sh\nif [ \"$1\" = config ]; then\n  printf '%s\\0' \"$IGNORE_TEST_REPO\"\n  exit 0\nfi\necho 'simulated clone failure' >&2\nexit 42\n",
+        "#!/bin/sh\nif [ \"$1\" = config ]; then\n  printf '%s\\0' \"$IGNORE_TEST_REPO\"\n  exit 0\nfi\n/bin/mkdir -p \"$IGNORE_TEST_REPO\"\necho preserved > \"$IGNORE_TEST_REPO/owner\"\necho 'simulated clone failure' >&2\nexit 42\n",
     )
     .expect("fake git should be writable");
     let mut permissions = fs::metadata(&git_path)
@@ -34,6 +34,15 @@ fn clone_failure_is_reported_without_leaving_repository_directory() {
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("simulated clone failure"));
-    assert!(!repo_path.exists());
+    assert_eq!(
+        fs::read_to_string(repo_path.join("owner")).expect("competing repository should remain"),
+        "preserved\n"
+    );
+    assert_eq!(
+        fs::read_dir(&test_root)
+            .expect("temporary directory should be readable")
+            .count(),
+        2
+    );
     fs::remove_dir_all(&test_root).expect("temporary directory should be removable");
 }

--- a/tests/clone_failure.rs
+++ b/tests/clone_failure.rs
@@ -1,0 +1,39 @@
+#![cfg(unix)]
+
+use std::{
+    env, fs,
+    os::unix::fs::PermissionsExt,
+    process::{self, Command},
+};
+
+#[test]
+fn clone_failure_is_reported_without_leaving_repository_directory() {
+    let test_root = env::temp_dir().join(format!("git-ignore-clone-failure-{}", process::id()));
+    let bin_dir = test_root.join("bin");
+    let repo_path = test_root.join("repository");
+    fs::create_dir_all(&bin_dir).expect("temporary bin directory should be creatable");
+
+    let git_path = bin_dir.join("git");
+    fs::write(
+        &git_path,
+        "#!/bin/sh\nif [ \"$1\" = config ]; then\n  printf '%s\\0' \"$IGNORE_TEST_REPO\"\n  exit 0\nfi\necho 'simulated clone failure' >&2\nexit 42\n",
+    )
+    .expect("fake git should be writable");
+    let mut permissions = fs::metadata(&git_path)
+        .expect("fake git metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&git_path, permissions).expect("fake git should be executable");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_git-ignore"))
+        .arg("rust")
+        .env("PATH", &bin_dir)
+        .env("IGNORE_TEST_REPO", &repo_path)
+        .output()
+        .expect("git-ignore should run");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("simulated clone failure"));
+    assert!(!repo_path.exists());
+    fs::remove_dir_all(&test_root).expect("temporary directory should be removable");
+}


### PR DESCRIPTION
## Purpose
Prevent failed initial clones from being reported as successful or poisoning later runs with an incomplete repository directory.

## Changes
- propagate a nonzero `git clone` status with Git stderr
- clone into an atomically owned staging directory and install it with rename
- clean up only staging owned by the current invocation, preserving concurrent destinations
- pass the repository path to Git without lossy string conversion
- add a CLI regression test covering failure reporting, cleanup, and concurrent destination preservation

## TDD
The initial regression test failed on `main` because the command exited successfully, discarded clone stderr, and left the repository directory. A review-driven concurrency test then failed because the first patch deleted a destination created by a competing process. Both pass after the staging implementation.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all-targets`
- `cargo audit --deny warnings`
- `cargo llvm-cov --all-targets --summary-only` (41.20% line coverage)
- `mise exec actionlint@1.7.12 -- actionlint .github/workflows/ci.yml`
- real clone E2E against `github/gitignore`

## Related issues
No existing issue; found during scheduled maintenance.